### PR TITLE
RFC: EC overwrite support

### DIFF
--- a/src/common/config_opts.h
+++ b/src/common/config_opts.h
@@ -819,6 +819,12 @@ OPTION(osd_scrub_priority, OPT_U32, 5)
 OPTION(osd_scrub_cost, OPT_U32, 50<<20) 
 
 /**
+ * ec overwrite count and size limit
+ */
+OPTION(osd_ec_overwrite_max_count, OPT_U32, 10)
+OPTION(osd_ec_overwrite_max_size, OPT_U64, 100*1024L*1024L)
+
+/**
  * osd_recovery_op_warn_multiple scales the normal warning threshhold,
  * osd_op_complaint_time, so that slow recovery ops won't cause noise
  */

--- a/src/messages/MOSDECSubOpApply.h
+++ b/src/messages/MOSDECSubOpApply.h
@@ -1,0 +1,55 @@
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
+// vim: ts=8 sw=2 smarttab
+
+#ifndef MOSDECSUBOPAPPLY_H
+#define MOSDECSUBOPAPPLY_H
+
+#include "msg/Message.h"
+#include "osd/osd_types.h"
+#include "osd/ECMsgTypes.h"
+
+class MOSDECSubOpApply : public Message {
+  static const int HEAD_VERSION = 1;
+  static const int COMPAT_VERSION = 1;
+  
+public:
+  spg_t pgid;
+  epoch_t map_epoch;
+  ECSubApply op;
+  
+  int get_cost() const {
+    return 0;
+  }
+  
+  MOSDECSubOpApply()
+    : Message(MSG_OSD_EC_APPLY, HEAD_VERSION, COMPAT_VERSION)
+    {}
+  MOSDECSubOpApply(ECSubApply &in_op)
+    : Message(MSG_OSD_EC_APPLY, HEAD_VERSION, COMPAT_VERSION) {
+    op.claim(in_op);
+  }
+
+  virtual void decode_payload() {
+    bufferlist::iterator p = payload.begin();
+    ::decode(pgid, p);
+    ::decode(map_epoch, p);
+    ::decode(op, p);
+  }
+
+  virtual void encode_payload(uint64_t features) {
+    ::encode(pgid, payload);
+    ::encode(map_epoch, payload);
+    ::encode(op, payload, features);
+  }
+
+  const char *get_type_name() const { return "MOSDECSubOpApply"; }
+
+  void print(ostream& out) const {
+    out << "MOSDECSubOpApply(" << pgid
+	<< " " << map_epoch
+	<< " " << op;
+    out << ")";
+  }
+};
+
+#endif

--- a/src/messages/MOSDECSubOpApplyReply.h
+++ b/src/messages/MOSDECSubOpApplyReply.h
@@ -1,0 +1,52 @@
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
+// vim: ts=8 sw=2 smarttab
+
+#ifndef MOSDECSUBOPAPPLYREPLY_H
+#define	MOSDECSUBOPAPPLYREPLY_H
+
+#include "msg/Message.h"
+#include "osd/osd_types.h"
+#include "osd/ECMsgTypes.h"
+
+class MOSDECSubOpApplyReply : public Message {
+  static const int HEAD_VERSION = 1;
+  static const int COMPAT_VERSION = 1;
+
+public:
+  spg_t pgid;
+  epoch_t map_epoch;
+  ECSubApplyReply op;
+
+  int get_cost() const {
+    return 0;
+  }
+
+  MOSDECSubOpApplyReply() :
+    Message(MSG_OSD_EC_APPLY_REPLY, HEAD_VERSION, COMPAT_VERSION)
+    {}
+
+  virtual void decode_payload() {
+    bufferlist::iterator p = payload.begin();
+    ::decode(pgid, p);
+    ::decode(map_epoch, p);
+    ::decode(op, p);
+  }
+
+  virtual void encode_payload(uint64_t features) {
+    ::encode(pgid, payload);
+    ::encode(map_epoch, payload);
+    ::encode(op, payload);
+  }
+
+  const char *get_type_name() const { return "MOSDECSubOpApplyReply"; }
+
+  void print(ostream& out) const {
+    out << "MOSDECSubOpApplyReply(" << pgid
+	<< " " << map_epoch
+	<< " " << op;
+    out << ")";
+  }
+};
+
+#endif
+

--- a/src/messages/Makefile.am
+++ b/src/messages/Makefile.am
@@ -95,6 +95,8 @@ noinst_HEADERS += \
 	messages/MOSDECSubOpWriteReply.h \
 	messages/MOSDECSubOpRead.h \
 	messages/MOSDECSubOpReadReply.h \
+	messages/MOSDECSubOpApply.h \
+	messages/MOSDECSubOpApplyReply.h \
 	messages/MBackfillReserve.h \
 	messages/MRecoveryReserve.h \
 	messages/MMonQuorumService.h \

--- a/src/msg/Message.cc
+++ b/src/msg/Message.cc
@@ -169,6 +169,8 @@ using namespace std;
 #include "messages/MOSDECSubOpWriteReply.h"
 #include "messages/MOSDECSubOpRead.h"
 #include "messages/MOSDECSubOpReadReply.h"
+#include "messages/MOSDECSubOpApply.h"
+#include "messages/MOSDECSubOpApplyReply.h"
 
 #define DEBUGLVL  10    // debug level of output
 
@@ -507,7 +509,13 @@ Message *decode_message(CephContext *cct, int crcflags,
   case MSG_OSD_EC_READ_REPLY:
     m = new MOSDECSubOpReadReply;
     break;
-   // auth
+  case MSG_OSD_EC_APPLY:
+    m = new MOSDECSubOpApply;
+    break;
+  case MSG_OSD_EC_APPLY_REPLY:
+    m = new MOSDECSubOpApplyReply;
+    break;
+    // auth
   case CEPH_MSG_AUTH:
     m = new MAuth;
     break;

--- a/src/msg/Message.h
+++ b/src/msg/Message.h
@@ -117,6 +117,8 @@
 #define MSG_OSD_REPOP         112
 #define MSG_OSD_REPOPREPLY    113
 
+#define MSG_OSD_EC_APPLY       114
+#define MSG_OSD_EC_APPLY_REPLY 115
 
 // *** MDS ***
 

--- a/src/osd/ECBackend.cc
+++ b/src/osd/ECBackend.cc
@@ -1131,7 +1131,8 @@ void ECBackend::handle_sub_read(
             pair<uint64_t, uint64_t> &ver_off = shards_to_write[shard_id];
             // ver_off = sinfo.offset_len_to_stripe_bounds(ow_iter->second);
             // no overlap
-            if ( (j->get<0>() + j->get<1>() ) < ver_off.first
+            // this shard no overwrite or needed read scope has no overlap with overwrite
+            if ( ver_off.second == 0 || (j->get<0>() + j->get<1>() ) < ver_off.first
                 || j->get<0>() > (ver_off.first + ver_off.second) )
               continue;
 

--- a/src/osd/ECBackend.cc
+++ b/src/osd/ECBackend.cc
@@ -2501,6 +2501,16 @@ void ECBackend::rollback_append(
       old_size));
 }
 
+void ECBackend::rollback_ec_overwrite(
+  const hobject_t &hoid,
+  version_t write_version,
+  ObjectStore::Transaction *t)
+{
+  t->remove(
+    coll,
+    ghobject_t(hoid, write_version, get_parent()->whoami_shard().shard));
+}
+
 void ECBackend::be_deep_scrub(
   const hobject_t &poid,
   uint32_t seed,

--- a/src/osd/ECBackend.cc
+++ b/src/osd/ECBackend.cc
@@ -1787,6 +1787,11 @@ void ECBackend::on_change()
   }
   in_progress_client_reads.clear();
   shard_to_read_map.clear();
+
+  in_progress_write_tid.clear();
+  tid_to_overwrite_map.clear();
+  pending_op.clear();
+
   clear_recovery_state();
 }
 

--- a/src/osd/ECBackend.cc
+++ b/src/osd/ECBackend.cc
@@ -2701,10 +2701,10 @@ void ECBackend::start_apply_op(const hobject_t &hoid, WriteOp *op) {
     }
   }
  
-  version_t last_apply_version = 
-      ow_info->overwrite_history.rbegin()->first;
-  bufferlist bl;
-  ::encode(last_apply_version, bl);
+  // version_t last_apply_version = 
+  //     ow_info->overwrite_history.rbegin()->first;
+  // bufferlist bl;
+  // ::encode(last_apply_version, bl);
 
   for (set<pg_shard_t>::const_iterator i =
          get_parent()->get_actingbackfill_shards().begin();
@@ -2714,26 +2714,26 @@ void ECBackend::start_apply_op(const hobject_t &hoid, WriteOp *op) {
     apply_progress.pending_apply.insert(*i);
 
     // generator pglog
-    //    vector<pg_log_entry_t> log_entries;
-    //    eversion_t at_version = get_parent()->get_version();
-    //    log_entries.push_back(pg_log_entry_t(
-    //        pg_log_entry_t::EC_APPLY,
-    //        hoid,
-    //        at_version,
-    //        ctx->obs->oi.version,
-    //	ctx->user_at_version,
-    //        ctx->reqid,
-    //	ctx->mtime));
+    // vector<pg_log_entry_t> log_entries;
+    // eversion_t at_version = get_parent()->get_version();
+    // log_entries.push_back(pg_log_entry_t(
+    //     pg_log_entry_t::EC_APPLY,
+    //     hoid,
+    //     at_version,
+    //     ctx->obs->oi.version,
+    //     ctx->user_at_version,
+    //     ctx->reqid,
+    //     ctx->mtime));
     // set ObjectModDesc
     
     // use xattr record the applied version
     // incase primary osd down, then scan pglog
     // and use this version to get the apply progress
-    trans[i->shard].setattr(
-      coll_t(spg_t(pgid, i->shard)),
-      ghobject_t(hoid, ghobject_t::NO_GEN, i->shard),
-      APPLY_KEY,
-      bl);
+    // trans[i->shard].setattr(
+    //   coll_t(spg_t(pgid, i->shard)),
+    //   ghobject_t(hoid, ghobject_t::NO_GEN, i->shard),
+    //   APPLY_KEY,
+    //   bl);
     // remove old overwrite info
     trans[i->shard].rmattr(
       coll_t(spg_t(pgid, i->shard)),
@@ -2862,7 +2862,9 @@ ECBackend::OverwriteInfoRef ECBackend::get_overwrite_info(
       coll,
       ghobject_t(hoid, version, get_parent()->whoami_shard().shard),
       &st);
-    OverwriteInfo ow_info;
+    OverwriteInfo ow_info(
+        cct->_conf->osd_ec_overwrite_max_count,
+        cct->_conf->osd_ec_overwrite_max_size);
     if (r >= 0) {
       bufferlist bl;
       r = store->getattr(

--- a/src/osd/ECBackend.h
+++ b/src/osd/ECBackend.h
@@ -379,7 +379,7 @@ public:
   };
   friend ostream &operator<<(ostream &lhs, const Op &rhs);
 
-  class OverwriteInfo {
+  struct OverwriteInfo {
     map<version_t, pair<uint64_t, uint64_t> > overwrite_history;
   public:
     void overwrite(version_t version, uint64_t off, uint64_t len) {

--- a/src/osd/ECBackend.h
+++ b/src/osd/ECBackend.h
@@ -395,6 +395,12 @@ public:
     }
     void encode(bufferlist &bl) const;
     void decode(bufferlist::iterator &bl);
+    map<version_t, pair<uint64_t, uint64_t> >::iterator begin() {
+      return overwrite_history.begin();
+    }
+    map<version_t, pair<uint64_t, uint64_t> >::iterator end() {
+      return overwrite_history.end();
+    }
   };
   typedef ceph::shared_ptr<OverwriteInfo> OverwriteInfoRef;
 

--- a/src/osd/ECBackend.h
+++ b/src/osd/ECBackend.h
@@ -426,6 +426,7 @@ public:
     uint64_t len;
     uint32_t fadvise_flags;
     bufferlist bl;
+    uint64_t append_off;
 
     set<pg_shard_t> missing_on;
     set<shard_id_t> missing_on_shards;

--- a/src/osd/ECBackend.h
+++ b/src/osd/ECBackend.h
@@ -415,6 +415,9 @@ public:
     map<version_t, pair<uint64_t, uint64_t> >::iterator end() {
       return overwrite_history.end();
     }
+    map<version_t, pair<uint64_t, uint64_t> >::size_type size() {
+      return overwrite_history.size();
+    }
   };
   typedef ceph::shared_ptr<OverwriteInfo> OverwriteInfoRef;
 
@@ -557,7 +560,7 @@ public:
 				    const map<string,bufferptr> *attr = NULL);
 
   friend struct ReadCB;
-  bool check_op(Op *op);
+  void check_op(Op *op);
   void start_write(Op *op);
 
   friend struct OnOverwriteReadComplete;
@@ -569,8 +572,11 @@ public:
     RecoveryMessages *m);
 
   map<ceph_tid_t, WriteOp> tid_to_overwrite_map;
+  // kepp the tid util write apply
   map<hobject_t, ceph_tid_t, hobject_t::BitwiseComparator> in_progress_write_tid;
+  // keep the op util write submit
   list<Op*> pending_op;
+  void write_submit_done(Op *op);
   void continue_next_op();
   void update_op_version(Op *op) {
     // update the write version

--- a/src/osd/ECBackend.h
+++ b/src/osd/ECBackend.h
@@ -596,6 +596,11 @@ public:
     uint64_t old_size,
     ObjectStore::Transaction *t);
 
+  void rollback_ec_overwrite(
+    const hobject_t &hoid,
+    version_t write_version,
+    ObjectStore::Transaction *t);
+
   bool scrub_supported() { return true; }
   bool auto_repair_supported() const { return true; }
 

--- a/src/osd/ECBackend.h
+++ b/src/osd/ECBackend.h
@@ -592,7 +592,8 @@ public:
 
   // history overwrite
   SharedPtrRegistry<hobject_t, OverwriteInfo, hobject_t::BitwiseComparator> overwrite_info_registry;
-  OverwriteInfoRef get_overwrite_info(const hobject_t &hoid);
+  OverwriteInfoRef get_overwrite_info(const hobject_t &hoid,
+                                      const version_t version = ghobject_t::NO_GEN);
 
 public:
   ECBackend(
@@ -630,6 +631,11 @@ public:
   void rollback_ec_overwrite(
     const hobject_t &hoid,
     version_t write_version,
+    ObjectStore::Transaction *t);
+
+  void trim_stashed_object(
+    const hobject_t &hoid,
+    version_t old_version,
     ObjectStore::Transaction *t);
 
   bool scrub_supported() { return true; }

--- a/src/osd/ECBackend.h
+++ b/src/osd/ECBackend.h
@@ -542,7 +542,7 @@ public:
 				    const map<string,bufferptr> *attr = NULL);
 
   friend struct ReadCB;
-  void check_op(Op *op);
+  bool check_op(Op *op);
   void start_write(Op *op);
 
   friend struct OnOverwriteReadComplete;
@@ -555,7 +555,9 @@ public:
     RecoveryMessages *m);
 
   map<ceph_tid_t, WriteOp> tid_to_overwrite_map;
-  map<hobject_t, ceph_tid_t, hobject_t::BitwiseComparator> ongoing_write_tid;
+  map<hobject_t, list<ceph_tid_t>, hobject_t::BitwiseComparator> in_progress_write_tid;
+  Mutex in_progress_write_lock;
+  void continue_same_oid_write(const hobject_t &hoid);
 
   // history overwrite
   SharedPtrRegistry<hobject_t, OverwriteInfo, hobject_t::BitwiseComparator> overwrite_info_registry;

--- a/src/osd/ECMsgTypes.cc
+++ b/src/osd/ECMsgTypes.cc
@@ -181,6 +181,7 @@ void ECSubRead::encode(bufferlist &bl, uint64_t features) const
   ::encode(to_read, bl);
   ::encode(attrs_to_read, bl);
   ::encode(recovery_read, bl);
+  ::encode(for_recovery, bl);
   ENCODE_FINISH(bl);
 }
 
@@ -205,8 +206,10 @@ void ECSubRead::decode(bufferlist::iterator &bl)
     ::decode(to_read, bl);
   }
   ::decode(attrs_to_read, bl);
-  if (struct_v >= 3) 
+  if (struct_v >= 3) {
     ::decode(recovery_read, bl);
+    ::decode(for_recovery, bl);
+  }
   DECODE_FINISH(bl);
 }
 

--- a/src/osd/ECMsgTypes.cc
+++ b/src/osd/ECMsgTypes.cc
@@ -175,11 +175,12 @@ void ECSubRead::encode(bufferlist &bl, uint64_t features) const
     return;
   }
 
-  ENCODE_START(2, 2, bl);
+  ENCODE_START(3, 2, bl);
   ::encode(from, bl);
   ::encode(tid, bl);
   ::encode(to_read, bl);
   ::encode(attrs_to_read, bl);
+  ::encode(recovery_read, bl);
   ENCODE_FINISH(bl);
 }
 
@@ -204,6 +205,8 @@ void ECSubRead::decode(bufferlist::iterator &bl)
     ::decode(to_read, bl);
   }
   ::decode(attrs_to_read, bl);
+  if (struct_v >= 3) 
+    ::decode(recovery_read, bl);
   DECODE_FINISH(bl);
 }
 
@@ -276,23 +279,26 @@ void ECSubRead::generate_test_instances(list<ECSubRead*>& o)
 
 void ECSubReadReply::encode(bufferlist &bl) const
 {
-  ENCODE_START(1, 1, bl);
+  ENCODE_START(2, 1, bl);
   ::encode(from, bl);
   ::encode(tid, bl);
   ::encode(buffers_read, bl);
   ::encode(attrs_read, bl);
   ::encode(errors, bl);
+  ::encode(recovery_buffers_read, bl);
   ENCODE_FINISH(bl);
 }
 
 void ECSubReadReply::decode(bufferlist::iterator &bl)
 {
-  DECODE_START(1, bl);
+  DECODE_START(2, bl);
   ::decode(from, bl);
   ::decode(tid, bl);
   ::decode(buffers_read, bl);
   ::decode(attrs_read, bl);
   ::decode(errors, bl);
+  if (struct_v >= 2)
+    ::decode(recovery_buffers_read, bl);
   DECODE_FINISH(bl);
 }
 

--- a/src/osd/ECMsgTypes.cc
+++ b/src/osd/ECMsgTypes.cc
@@ -405,6 +405,7 @@ void ECSubApply::encode(bufferlist &bl) const
   ::encode(tid, bl);
   ::encode(hoid, bl);
   ::encode(t, bl);
+  ::encode(log_entries, bl);
   ENCODE_FINISH(bl);
 }
 
@@ -415,6 +416,7 @@ void ECSubApply::decode(bufferlist::iterator &bl)
   ::decode(tid, bl);
   ::decode(hoid, bl);
   ::decode(t, bl);
+  ::decode(log_entries, bl);
   DECODE_FINISH(bl);
 }
 

--- a/src/osd/ECMsgTypes.cc
+++ b/src/osd/ECMsgTypes.cc
@@ -397,3 +397,76 @@ void ECSubReadReply::generate_test_instances(list<ECSubReadReply*>& o)
   o.back()->attrs_read[hoid2]["_"] = bl2;
   o.back()->errors[hoid1] = -2;
 }
+
+void ECSubApply::encode(bufferlist &bl) const
+{
+  ENCODE_START(1, 1, bl);
+  ::encode(from, bl);
+  ::encode(tid, bl);
+  ::encode(hoid, bl);
+  ::encode(t, bl);
+  ENCODE_FINISH(bl);
+}
+
+void ECSubApply::decode(bufferlist::iterator &bl)
+{
+  DECODE_START(1, bl);
+  ::decode(from, bl);
+  ::decode(tid, bl);
+  ::decode(hoid, bl);
+  ::decode(t, bl);
+  DECODE_FINISH(bl);
+}
+
+std::ostream &operator<<(
+  std::ostream &lhs, const ECSubApply &rhs)
+{
+  return lhs
+    << "ECSubApply(tid=" << rhs.tid
+    << ")";
+}
+
+void ECSubApply::dump(Formatter *f) const
+{
+
+}
+
+void ECSubApply::generate_test_instances(list<ECSubApply*>& o)
+{
+
+}
+
+
+void ECSubApplyReply::encode(bufferlist &bl) const
+{
+  ENCODE_START(1, 1, bl);
+  ::encode(from, bl);
+  ::encode(tid, bl);
+  ENCODE_FINISH(bl);
+}
+
+void ECSubApplyReply::decode(bufferlist::iterator &bl)
+{
+  DECODE_START(1, bl);
+  ::decode(from, bl);
+  ::decode(tid, bl);
+  DECODE_FINISH(bl);
+}
+
+std::ostream &operator<<(
+  std::ostream &lhs, const ECSubApplyReply &rhs)
+{
+  return lhs
+    << "ECSubApplyReply(tid=" << rhs.tid
+    << " from=" << rhs.from << ")";
+}
+
+void ECSubApplyReply::dump(Formatter *f) const
+{
+
+}
+
+void ECSubApplyReply::generate_test_instances(list<ECSubApplyReply*>& o)
+{
+
+}

--- a/src/osd/ECMsgTypes.h
+++ b/src/osd/ECMsgTypes.h
@@ -102,6 +102,7 @@ struct ECSubRead {
   ceph_tid_t tid;
   map<hobject_t, list<boost::tuple<uint64_t, uint64_t, uint32_t> >, hobject_t::BitwiseComparator> to_read;
   set<hobject_t, hobject_t::BitwiseComparator> attrs_to_read;
+  map<hobject_t, list<version_t>, hobject_t::BitwiseComparator> recovery_read;
   void encode(bufferlist &bl, uint64_t features) const;
   void decode(bufferlist::iterator &bl);
   void dump(Formatter *f) const;
@@ -115,6 +116,7 @@ struct ECSubReadReply {
   map<hobject_t, list<pair<uint64_t, bufferlist> >, hobject_t::BitwiseComparator> buffers_read;
   map<hobject_t, map<string, bufferlist>, hobject_t::BitwiseComparator> attrs_read;
   map<hobject_t, int, hobject_t::BitwiseComparator> errors;
+  map<hobject_t, list<pair<version_t, bufferlist> >, hobject_t::BitwiseComparator> recovery_buffers_read;
   void encode(bufferlist &bl) const;
   void decode(bufferlist::iterator &bl);
   void dump(Formatter *f) const;

--- a/src/osd/ECMsgTypes.h
+++ b/src/osd/ECMsgTypes.h
@@ -103,6 +103,7 @@ struct ECSubRead {
   map<hobject_t, list<boost::tuple<uint64_t, uint64_t, uint32_t> >, hobject_t::BitwiseComparator> to_read;
   set<hobject_t, hobject_t::BitwiseComparator> attrs_to_read;
   map<hobject_t, list<version_t>, hobject_t::BitwiseComparator> recovery_read;
+  bool for_recovery;
   void encode(bufferlist &bl, uint64_t features) const;
   void decode(bufferlist::iterator &bl);
   void dump(Formatter *f) const;

--- a/src/osd/ECMsgTypes.h
+++ b/src/osd/ECMsgTypes.h
@@ -125,6 +125,43 @@ struct ECSubReadReply {
 };
 WRITE_CLASS_ENCODER(ECSubReadReply)
 
+struct ECSubApply {
+  pg_shard_t from;
+  ceph_tid_t tid;
+  hobject_t hoid;
+  ObjectStore::Transaction t;
+//  vector<pg_log_entry_t> log_entries;
+  ECSubApply() :tid(0) {};
+  ECSubApply(
+    pg_shard_t from,
+    ceph_tid_t tid,
+    hobject_t hoid,
+    const ObjectStore::Transaction &t)
+    : from(from), tid(tid),
+      hoid(hoid), t(t) {}
+  void claim(ECSubApply &other) {
+    from = other.from;
+    tid = other.tid;
+    hoid = other.hoid;
+    t.swap(other.t);
+  }
+  void encode(bufferlist &bl) const;
+  void decode(bufferlist::iterator &bl);
+  void dump(Formatter *f) const;
+  static void generate_test_instances(list<ECSubApply*>& o);
+};
+WRITE_CLASS_ENCODER(ECSubApply)
+
+struct ECSubApplyReply {
+  pg_shard_t from;
+  ceph_tid_t tid;
+  void encode(bufferlist &bl) const;
+  void decode(bufferlist::iterator &bl);
+  void dump(Formatter *f) const;
+  static void generate_test_instances(list<ECSubApplyReply*>& o);
+};
+WRITE_CLASS_ENCODER(ECSubApplyReply)
+
 std::ostream &operator<<(
   std::ostream &lhs, const ECSubWrite &rhs);
 std::ostream &operator<<(
@@ -133,5 +170,9 @@ std::ostream &operator<<(
   std::ostream &lhs, const ECSubRead &rhs);
 std::ostream &operator<<(
   std::ostream &lhs, const ECSubReadReply &rhs);
+std::ostream &operator<<(
+  std::ostream &lhs, const ECSubApply &rhs);
+std::ostream &operator<<(
+  std::ostream &lhs, const ECSubApplyReply &rhs);
 
 #endif

--- a/src/osd/ECMsgTypes.h
+++ b/src/osd/ECMsgTypes.h
@@ -130,20 +130,23 @@ struct ECSubApply {
   ceph_tid_t tid;
   hobject_t hoid;
   ObjectStore::Transaction t;
-//  vector<pg_log_entry_t> log_entries;
+  vector<pg_log_entry_t> log_entries;
   ECSubApply() :tid(0) {};
   ECSubApply(
     pg_shard_t from,
     ceph_tid_t tid,
     hobject_t hoid,
-    const ObjectStore::Transaction &t)
+    const ObjectStore::Transaction &t,
+    vector<pg_log_entry_t> log_entries)
     : from(from), tid(tid),
-      hoid(hoid), t(t) {}
+      hoid(hoid), t(t),
+      log_entries(log_entries) {}
   void claim(ECSubApply &other) {
     from = other.from;
     tid = other.tid;
     hoid = other.hoid;
     t.swap(other.t);
+    log_entries.swap(other.log_entries);
   }
   void encode(bufferlist &bl) const;
   void decode(bufferlist::iterator &bl);

--- a/src/osd/ECTransaction.cc
+++ b/src/osd/ECTransaction.cc
@@ -28,6 +28,9 @@ struct AppendObjectsGenerator: public boost::static_visitor<void> {
   void operator()(const ECTransaction::AppendOp &op) {
     out->insert(op.oid);
   }
+  void operator()(const ECTransaction::WriteOp &op) {
+    out->insert(op.oid);
+  }
   void operator()(const ECTransaction::TouchOp &op) {
     out->insert(op.oid);
   }
@@ -176,6 +179,9 @@ struct TransGenerator : public boost::static_visitor<void> {
 	ECUtil::get_hinfo_key(),
 	hbuf);
     }
+  }
+  void operator()(const ECTransaction::WriteOp &op) {
+    // done in ECBackend
   }
   void operator()(const ECTransaction::CloneOp &op) {
     assert(hash_infos.count(op.source));

--- a/src/osd/ECTransaction.h
+++ b/src/osd/ECTransaction.h
@@ -151,7 +151,7 @@ public:
   WriteOp* get_writeop() {
     assert(!writeops.empty());
     WriteOp* op = &(writeops.front());
-    writeops.pop_front();
+    // writeops.pop_front();
     return op;
   }
   void stash(

--- a/src/osd/ECTransaction.h
+++ b/src/osd/ECTransaction.h
@@ -32,6 +32,15 @@ public:
     AppendOp(const hobject_t &oid, uint64_t off, bufferlist &bl, uint32_t flags)
       : oid(oid), off(off), bl(bl), fadvise_flags(flags) {}
   };
+  struct WriteOp {
+    hobject_t oid;
+    uint64_t off;
+    uint64_t len;
+    bufferlist bl;
+    uint32_t fadvise_flags;
+    WriteOp(const hobject_t &oid, uint64_t off, uint64_t len, bufferlist &bl, uint32_t flags)
+      : oid(oid), off(off), len(len), bl(bl), fadvise_flags(flags) {}
+  };
   struct CloneOp {
     hobject_t source;
     hobject_t target;
@@ -88,6 +97,7 @@ public:
   struct NoOp {};
   typedef boost::variant<
     AppendOp,
+    // WriteOp,
     CloneOp,
     RenameOp,
     StashOp,
@@ -98,9 +108,11 @@ public:
     AllocHintOp,
     NoOp> Op;
   list<Op> ops;
+  list<WriteOp> writeops;
   uint64_t written;
+  bool offset_write;
 
-  ECTransaction() : written(0) {}
+  ECTransaction() : written(0), offset_write(false) {}
   /// Write
   void touch(
     const hobject_t &hoid) {
@@ -119,6 +131,28 @@ public:
     written += len;
     assert(len == bl.length());
     ops.push_back(AppendOp(hoid, off, bl, fadvise_flags));
+  }
+  void write(
+    const hobject_t &hoid,
+    uint64_t off,
+    uint64_t len,
+    bufferlist &bl,
+    uint32_t fadvise_flags) {
+    if (len == 0) {
+        touch(hoid);
+        return;
+    }
+    offset_write = true;
+
+    written += off + len > written ? (off + len - written) : 0;
+    assert(len == bl.length());
+    writeops.push_back(WriteOp(hoid, off, len, bl, fadvise_flags));
+  }
+  WriteOp* get_writeop() {
+    assert(!writeops.empty());
+    WriteOp* op = &(writeops.front());
+    writeops.pop_front();
+    return op;
   }
   void stash(
     const hobject_t &hoid,
@@ -173,7 +207,7 @@ public:
     ops.push_back(NoOp());
   }
   bool empty() const {
-    return ops.empty();
+    return ops.empty() && writeops.empty();
   }
   uint64_t get_bytes_written() const {
     return written;

--- a/src/osd/ECUtil.h
+++ b/src/osd/ECUtil.h
@@ -84,7 +84,7 @@ public:
     return make_pair(off, len);
   }
   map<int, pair<uint64_t, uint64_t>> offset_len_to_chunk_offset(
-    pair<uint64_t, uint64_t> in, int chunk_count) const {
+      pair<uint64_t, uint64_t> in, int chunk_count) const {
     pair<uint64_t, uint64_t> bounds = offset_len_to_stripe_bounds(in);
     pair<uint64_t, uint64_t> chunk_off_len = aligned_offset_len_to_chunk(bounds);
 
@@ -97,7 +97,7 @@ public:
         tmp.first += stripe_width;
       }
       // find the chunk end
-      if (tmp.first < in.second && tmp.first < bounds.first + bounds.second) {
+      if (tmp.first < (in.first + in.second) && tmp.first < bounds.first + bounds.second) {
         uint64_t tmp_end = tmp.first + chunk_size;
         tmp.second += chunk_size;
         while (tmp_end < in.second) {

--- a/src/osd/OSD.cc
+++ b/src/osd/OSD.cc
@@ -90,6 +90,8 @@
 #include "messages/MOSDECSubOpWriteReply.h"
 #include "messages/MOSDECSubOpRead.h"
 #include "messages/MOSDECSubOpReadReply.h"
+#include "messages/MOSDECSubOpApply.h"
+#include "messages/MOSDECSubOpApplyReply.h"
 
 #include "messages/MOSDAlive.h"
 
@@ -5863,6 +5865,10 @@ epoch_t op_required_epoch(OpRequestRef op)
     return replica_op_required_epoch<MOSDECSubOpRead, MSG_OSD_EC_READ>(op);
   case MSG_OSD_EC_READ_REPLY:
     return replica_op_required_epoch<MOSDECSubOpReadReply, MSG_OSD_EC_READ_REPLY>(op);
+  case MSG_OSD_EC_APPLY:
+    return replica_op_required_epoch<MOSDECSubOpApply, MSG_OSD_EC_APPLY>(op);
+  case MSG_OSD_EC_APPLY_REPLY:
+    return replica_op_required_epoch<MOSDECSubOpApplyReply, MSG_OSD_EC_APPLY_REPLY>(op);
   case MSG_OSD_REP_SCRUB:
     return replica_op_required_epoch<MOSDRepScrub, MSG_OSD_REP_SCRUB>(op);
   default:
@@ -5977,6 +5983,12 @@ bool OSD::dispatch_op_fast(OpRequestRef& op, OSDMapRef& osdmap)
     break;
   case MSG_OSD_EC_READ_REPLY:
     handle_replica_op<MOSDECSubOpReadReply, MSG_OSD_EC_READ_REPLY>(op, osdmap);
+    break;
+  case MSG_OSD_EC_APPLY:
+    handle_replica_op<MOSDECSubOpApply, MSG_OSD_EC_APPLY>(op, osdmap);
+    break;
+  case MSG_OSD_EC_APPLY_REPLY:
+    handle_replica_op<MOSDECSubOpApplyReply, MSG_OSD_EC_APPLY_REPLY>(op, osdmap);
     break;
   case MSG_OSD_REP_SCRUB:
     handle_replica_op<MOSDRepScrub, MSG_OSD_REP_SCRUB>(op, osdmap);

--- a/src/osd/OSD.h
+++ b/src/osd/OSD.h
@@ -2281,6 +2281,8 @@ protected:
     case MSG_OSD_EC_READ:
     case MSG_OSD_EC_READ_REPLY:
     case MSG_OSD_REP_SCRUB:
+    case MSG_OSD_EC_APPLY:
+    case MSG_OSD_EC_APPLY_REPLY:
       return true;
     default:
       return false;

--- a/src/osd/PG.cc
+++ b/src/osd/PG.cc
@@ -37,6 +37,8 @@
 #include "messages/MOSDECSubOpWriteReply.h"
 #include "messages/MOSDECSubOpRead.h"
 #include "messages/MOSDECSubOpReadReply.h"
+#include "messages/MOSDECSubOpApply.h"
+#include "messages/MOSDECSubOpApplyReply.h"
 
 #include "messages/MOSDSubOp.h"
 #include "messages/MOSDRepOp.h"
@@ -5262,6 +5264,10 @@ bool PG::can_discard_request(OpRequestRef& op)
     return can_discard_replica_op<MOSDECSubOpRead, MSG_OSD_EC_READ>(op);
   case MSG_OSD_EC_READ_REPLY:
     return can_discard_replica_op<MOSDECSubOpReadReply, MSG_OSD_EC_READ_REPLY>(op);
+  case MSG_OSD_EC_APPLY:
+    return can_discard_replica_op<MOSDECSubOpApply, MSG_OSD_EC_APPLY>(op);
+  case MSG_OSD_EC_APPLY_REPLY:
+    return can_discard_replica_op<MOSDECSubOpApplyReply, MSG_OSD_EC_APPLY_REPLY>(op);
   case MSG_OSD_REP_SCRUB:
     return can_discard_replica_op<MOSDRepScrub, MSG_OSD_REP_SCRUB>(op);
 
@@ -5345,6 +5351,16 @@ bool PG::op_must_wait_for_map(epoch_t cur_epoch, OpRequestRef& op)
     return !have_same_or_newer_map(
       cur_epoch,
       static_cast<MOSDECSubOpReadReply*>(op->get_req())->map_epoch);
+
+  case MSG_OSD_EC_APPLY:
+    return !have_same_or_newer_map(
+      cur_epoch,
+      static_cast<MOSDECSubOpApply*>(op->get_req())->map_epoch);
+
+  case MSG_OSD_EC_APPLY_REPLY:
+    return !have_same_or_newer_map(
+      cur_epoch,
+      static_cast<MOSDECSubOpApplyReply*>(op->get_req())->map_epoch);
 
   case MSG_OSD_REP_SCRUB:
     return !have_same_or_newer_map(

--- a/src/osd/PGBackend.cc
+++ b/src/osd/PGBackend.cc
@@ -66,6 +66,12 @@ struct RollbackVisitor : public ObjectModDesc::Visitor {
   void update_snaps(set<snapid_t> &snaps) {
     // pass
   }
+  void ec_overwrite(version_t write_version) {
+    ObjectStore::Transaction temp;
+    pg->rollback_ec_overwrite(hoid, write_version, &temp);
+    temp.append(t);
+    temp.swap(t);
+  }
 };
 
 void PGBackend::rollback(
@@ -258,6 +264,13 @@ void PGBackend::rollback_create(
   t->remove(
     coll,
     ghobject_t(hoid, ghobject_t::NO_GEN, get_parent()->whoami_shard().shard));
+}
+
+void PGBackend::rollback_ec_overwrite(
+  const hobject_t &hoid,
+  version_t write_version,
+  ObjectStore::Transaction *t) {
+  assert(0);
 }
 
 void PGBackend::trim_stashed_object(

--- a/src/osd/PGBackend.h
+++ b/src/osd/PGBackend.h
@@ -143,6 +143,12 @@
        assert(m);
        return *m;
      }
+     virtual const eversion_t &get_shard_missing_object_have(pg_shard_t peer, hobject_t hoid) const {
+       const pg_missing_t &m = get_shard_missing(peer);
+       map<hobject_t, pg_missing_t::item>::const_iterator it = m.missing.find(hoid);
+       assert(it != m.missing.end());
+       return it->second.have;
+     }
 
      virtual const map<pg_shard_t, pg_info_t> &get_shard_info() const = 0;
      virtual const pg_info_t &get_shard_info(pg_shard_t peer) const {

--- a/src/osd/PGBackend.h
+++ b/src/osd/PGBackend.h
@@ -517,6 +517,11 @@
      const hobject_t &hoid,
      ObjectStore::Transaction *t);
 
+   void rollback_ec_overwrite(
+     const hobject_t &hoid,
+     version_t write_version,
+     ObjectStore::Transaction *t);
+
    /// Trim object stashed at stashed_version
    void trim_stashed_object(
      const hobject_t &hoid,

--- a/src/osd/PGBackend.h
+++ b/src/osd/PGBackend.h
@@ -235,6 +235,8 @@
 
      virtual LogClientTemp clog_error() = 0;
 
+     virtual int continue_blocked_async_read() = 0;
+
      virtual ~Listener() {}
    };
    Listener *parent;
@@ -570,6 +572,10 @@
      const list<pair<boost::tuple<uint64_t, uint64_t, uint32_t>,
 		pair<bufferlist*, Context*> > > &to_read,
      Context *on_complete, bool fast_read = false) = 0;
+   virtual bool is_objects_read_async_block(
+     const hobject_t &hoid) {
+     return false;
+   }
 
    virtual bool scrub_supported() = 0;
    virtual bool auto_repair_supported() const = 0;

--- a/src/osd/PGBackend.h
+++ b/src/osd/PGBackend.h
@@ -523,13 +523,13 @@
      const hobject_t &hoid,
      ObjectStore::Transaction *t);
 
-   void rollback_ec_overwrite(
+   virtual void rollback_ec_overwrite(
      const hobject_t &hoid,
      version_t write_version,
      ObjectStore::Transaction *t);
 
    /// Trim object stashed at stashed_version
-   void trim_stashed_object(
+   virtual void trim_stashed_object(
      const hobject_t &hoid,
      version_t stashed_version,
      ObjectStore::Transaction *t);

--- a/src/osd/PGBackend.h
+++ b/src/osd/PGBackend.h
@@ -166,6 +166,8 @@
        const hobject_t &hoid,
        map<string, bufferlist> &attrs) = 0;
 
+     virtual eversion_t get_version() = 0;
+
      virtual void op_applied(
        const eversion_t &applied_version) = 0;
 

--- a/src/osd/ReplicatedPG.cc
+++ b/src/osd/ReplicatedPG.cc
@@ -3849,16 +3849,17 @@ struct FillInVerifyExtent : public Context {
       return;
     // whole object?  can we verify the checksum?
     if (maybe_crc && *r == size) {
-      uint32_t crc = outdatap->crc32c(-1);
-      if (maybe_crc != crc) {
-        osd->clog->error() << std::hex << " full-object read crc 0x" << crc
-			   << " != expected 0x" << *maybe_crc
-			   << std::dec << " on " << soid << "\n";
-        if (!(flags & CEPH_OSD_OP_FLAG_FAILOK)) {
-	  *rval = -EIO;
-	  *r = 0;
-	}
-      }
+      // FIXME: temp disable crc
+      // uint32_t crc = outdatap->crc32c(-1);
+      // if (maybe_crc != crc) {
+      //   osd->clog->error() << std::hex << " full-object read crc 0x" << crc
+      //   		   << " != expected 0x" << *maybe_crc
+      //   		   << std::dec << " on " << soid << "\n";
+      //   if (!(flags & CEPH_OSD_OP_FLAG_FAILOK)) {
+      //     *rval = -EIO;
+      //     *r = 0;
+      //   }
+      // }
     }
   }
 };

--- a/src/osd/ReplicatedPG.cc
+++ b/src/osd/ReplicatedPG.cc
@@ -4802,7 +4802,12 @@ int ReplicatedPG::do_osd_ops(OpContext *ctx, vector<OSDOp>& ops)
 	  }
 	  ctx->mod_desc.create();
 	} else if (op.extent.offset == oi.size) {
-	  ctx->mod_desc.append(oi.size);
+          if (pool.info.require_rollback() &&
+              op.extent.offset % pool.info.required_alignment() == 0) {
+	    ctx->mod_desc.append(oi.size);
+          } else {
+            ctx->ec_overwrite = true;
+          }
 	} else {
 	  // ctx->mod_desc.mark_unrollbackable();
 	  if (pool.info.require_rollback()) {

--- a/src/osd/ReplicatedPG.h
+++ b/src/osd/ReplicatedPG.h
@@ -382,6 +382,9 @@ public:
     map<string, bufferlist> &attrs) {
     return get_object_context(hoid, true, &attrs);
   }
+  eversion_t get_version() {
+    return get_next_version();
+  }
   void log_operation(
     const vector<pg_log_entry_t> &logv,
     boost::optional<pg_hit_set_history_t> &hset_history,

--- a/src/osd/ReplicatedPG.h
+++ b/src/osd/ReplicatedPG.h
@@ -496,6 +496,7 @@ public:
     bool cache_evict;     ///< true if this is a cache eviction
     bool ignore_cache;    ///< true if IGNORE_CACHE flag is set
     bool ignore_log_op_stats;  // don't log op stats
+    bool ec_overwrite;    /// whether this op is an ec overwrite
 
     // side effects
     list<pair<watch_info_t,bool> > watch_connects; ///< new watch + will_ping flag
@@ -613,6 +614,7 @@ public:
       new_obs(obs->oi, obs->exists),
       modify(false), user_modify(false), undirty(false), cache_evict(false),
       ignore_cache(false), ignore_log_op_stats(false),
+      ec_overwrite(false),
       bytes_written(0), bytes_read(0), user_at_version(0),
       current_osd_subop_num(0),
       op_t(NULL),
@@ -636,6 +638,7 @@ public:
       op(_op), reqid(_reqid), ops(_ops), obs(NULL), snapset(0),
       modify(false), user_modify(false), undirty(false), cache_evict(false),
       ignore_cache(false), ignore_log_op_stats(false),
+      ec_overwrite(false),
       bytes_written(0), bytes_read(0), user_at_version(0),
       current_osd_subop_num(0),
       op_t(NULL),

--- a/src/osd/ReplicatedPG.h
+++ b/src/osd/ReplicatedPG.h
@@ -474,6 +474,8 @@ public:
 
   LogClientTemp clog_error() { return osd->clog->error(); }
 
+  int continue_blocked_async_read();
+
   /*
    * Capture all object state associated with an in-progress read or write.
    */

--- a/src/osd/osd_types.cc
+++ b/src/osd/osd_types.cc
@@ -5153,7 +5153,7 @@ void PushOp::generate_test_instances(list<PushOp*> &o)
 
 void PushOp::encode(bufferlist &bl) const
 {
-  ENCODE_START(1, 1, bl);
+  ENCODE_START(2, 1, bl);
   ::encode(soid, bl);
   ::encode(version, bl);
   ::encode(data, bl);
@@ -5164,12 +5164,13 @@ void PushOp::encode(bufferlist &bl) const
   ::encode(recovery_info, bl);
   ::encode(after_progress, bl);
   ::encode(before_progress, bl);
+  ::encode(ec_overwrite, bl);
   ENCODE_FINISH(bl);
 }
 
 void PushOp::decode(bufferlist::iterator &bl)
 {
-  DECODE_START(1, bl);
+  DECODE_START(2, bl);
   ::decode(soid, bl);
   ::decode(version, bl);
   ::decode(data, bl);
@@ -5180,6 +5181,8 @@ void PushOp::decode(bufferlist::iterator &bl)
   ::decode(recovery_info, bl);
   ::decode(after_progress, bl);
   ::decode(before_progress, bl);
+  if (struct_v >= 2)
+    ::decode(ec_overwrite, bl);
   DECODE_FINISH(bl);
 }
 

--- a/src/osd/osd_types.cc
+++ b/src/osd/osd_types.cc
@@ -3272,6 +3272,12 @@ void ObjectModDesc::visit(Visitor *visitor) const
 	visitor->update_snaps(snaps);
 	break;
       }
+      case EC_OVERWRITE: {
+        version_t write_version;
+        ::decode(write_version, bp);
+        visitor->ec_overwrite(write_version);
+        break;
+      }
       default:
 	assert(0 == "Invalid rollback code");
       }

--- a/src/osd/osd_types.h
+++ b/src/osd/osd_types.h
@@ -2502,6 +2502,7 @@ struct pg_log_entry_t {
     LOST_MARK = 7,   // lost new version, now EIO
     PROMOTE = 8,     // promoted object from another tier
     CLEAN = 9,       // mark an object clean
+    EC_OVERWRITE = 10,  // ec overwrite, belong to MODIFY
   };
   static const char *get_op_name(int op) {
     switch (op) {
@@ -2523,6 +2524,8 @@ struct pg_log_entry_t {
       return "l_mark  ";
     case CLEAN:
       return "clean   ";
+    case EC_OVERWRITE:
+      return "ec_overwrite";
     default:
       return "unknown ";
     }
@@ -2557,13 +2560,14 @@ struct pg_log_entry_t {
      {}
       
   bool is_clone() const { return op == CLONE; }
-  bool is_modify() const { return op == MODIFY; }
+  bool is_modify() const { return op == MODIFY || op == EC_OVERWRITE; }
   bool is_promote() const { return op == PROMOTE; }
   bool is_clean() const { return op == CLEAN; }
   bool is_backlog() const { return op == BACKLOG; }
   bool is_lost_revert() const { return op == LOST_REVERT; }
   bool is_lost_delete() const { return op == LOST_DELETE; }
   bool is_lost_mark() const { return op == LOST_MARK; }
+  bool is_ec_overwrite() const { return op == EC_OVERWRITE; }
 
   bool is_update() const {
     return
@@ -3850,6 +3854,7 @@ struct PushOp {
   bufferlist omap_header;
   map<string, bufferlist> omap_entries;
   map<string, bufferlist> attrset;
+  bool ec_overwrite;
 
   ObjectRecoveryInfo recovery_info;
   ObjectRecoveryProgress before_progress;

--- a/src/osd/osd_types.h
+++ b/src/osd/osd_types.h
@@ -2503,6 +2503,7 @@ struct pg_log_entry_t {
     PROMOTE = 8,     // promoted object from another tier
     CLEAN = 9,       // mark an object clean
     EC_OVERWRITE = 10,  // ec overwrite, belong to MODIFY
+    EC_APPLY = 11,      // ec overwrite apply
   };
   static const char *get_op_name(int op) {
     switch (op) {
@@ -2526,6 +2527,8 @@ struct pg_log_entry_t {
       return "clean   ";
     case EC_OVERWRITE:
       return "ec_overwrite";
+    case EC_APPLY:
+      return "ec_apply";
     default:
       return "unknown ";
     }
@@ -2568,11 +2571,12 @@ struct pg_log_entry_t {
   bool is_lost_delete() const { return op == LOST_DELETE; }
   bool is_lost_mark() const { return op == LOST_MARK; }
   bool is_ec_overwrite() const { return op == EC_OVERWRITE; }
+  bool is_ec_apply() const { return op == EC_APPLY; }
 
   bool is_update() const {
     return
       is_clone() || is_modify() || is_promote() || is_clean() ||
-      is_backlog() || is_lost_revert() || is_lost_mark();
+      is_backlog() || is_lost_revert() || is_lost_mark() || is_ec_apply();
   }
   bool is_delete() const {
     return op == DELETE || op == LOST_DELETE;

--- a/src/osd/osd_types.h
+++ b/src/osd/osd_types.h
@@ -2362,6 +2362,7 @@ public:
     virtual void rmobject(version_t old_version) {}
     virtual void create() {}
     virtual void update_snaps(set<snapid_t> &old_snaps) {}
+    virtual void ec_overwrite(version_t write_version) {}
     virtual ~Visitor() {}
   };
   void visit(Visitor *visitor) const;
@@ -2371,7 +2372,8 @@ public:
     SETATTRS = 2,
     DELETE = 3,
     CREATE = 4,
-    UPDATE_SNAPS = 5
+    UPDATE_SNAPS = 5,
+    EC_OVERWRITE = 6
   };
   ObjectModDesc() : can_local_rollback(true), rollback_info_completed(false) {}
   void claim(ObjectModDesc &other) {
@@ -2445,6 +2447,14 @@ public:
     ENCODE_START(1, 1, bl);
     append_id(UPDATE_SNAPS);
     ::encode(old_snaps, bl);
+    ENCODE_FINISH(bl);
+  }
+  void ec_overwrite(version_t write_version) {
+    if (!can_local_rollback || rollback_info_completed)
+      return;
+    ENCODE_START(1, 1, bl);
+    append_id(EC_OVERWRITE);
+    ::encode(write_version, bl);
     ENCODE_FINISH(bl);
   }
 

--- a/src/test/osd/TestECBackend.cc
+++ b/src/test/osd/TestECBackend.cc
@@ -18,6 +18,7 @@
 #include <signal.h>
 #include "osd/ECBackend.h"
 #include "gtest/gtest.h"
+#include "gmock/gmock.h"
 
 TEST(ECUtil, stripe_info_t)
 {
@@ -58,3 +59,48 @@ TEST(ECUtil, stripe_info_t)
             make_pair((uint64_t)0, 2*swidth));
 }
 
+TEST(ECUtil, stripe_info_t2)
+{
+  const uint64_t swidth = 8192;
+  const uint64_t ssize = 2;
+  const uint64_t chunk_count = 3;
+
+  ECUtil::stripe_info_t s(ssize, swidth);
+  map<int, pair<uint64_t, uint64_t>> shards_to_write;
+
+  shards_to_write = s.offset_len_to_chunk_offset(make_pair(10, 64), chunk_count);
+  ASSERT_THAT(shards_to_write[0], make_pair(0, 4096));
+  ASSERT_THAT(shards_to_write[1], make_pair(0, 0));
+  ASSERT_THAT(shards_to_write[2], make_pair(0, 4096));
+
+  shards_to_write = s.offset_len_to_chunk_offset(make_pair(4096, 4096), chunk_count);
+  ASSERT_THAT(shards_to_write[0], make_pair(0, 0));
+  ASSERT_THAT(shards_to_write[1], make_pair(0, 4096));
+  ASSERT_THAT(shards_to_write[2], make_pair(0, 4096));
+
+  shards_to_write = s.offset_len_to_chunk_offset(make_pair(4090, 10), chunk_count);
+  ASSERT_THAT(shards_to_write[0], make_pair(0, 4096));
+  ASSERT_THAT(shards_to_write[1], make_pair(0, 4096));
+  ASSERT_THAT(shards_to_write[2], make_pair(0, 4096));
+
+  shards_to_write = s.offset_len_to_chunk_offset(make_pair(8192, 4096), chunk_count);
+  ASSERT_THAT(shards_to_write[0], make_pair(4096, 4096));
+  ASSERT_THAT(shards_to_write[1], make_pair(0, 0));
+  ASSERT_THAT(shards_to_write[2], make_pair(4096, 4096));
+
+  shards_to_write = s.offset_len_to_chunk_offset(make_pair(8190, 10), chunk_count);
+  ASSERT_THAT(shards_to_write[0], make_pair(4096, 4096));
+  ASSERT_THAT(shards_to_write[1], make_pair(0, 4096));
+  ASSERT_THAT(shards_to_write[2], make_pair(0, 8192));
+
+  shards_to_write = s.offset_len_to_chunk_offset(make_pair(8190, 4100), chunk_count);
+  ASSERT_THAT(shards_to_write[0], make_pair(4096, 4096));
+  ASSERT_THAT(shards_to_write[1], make_pair(0, 8192));
+  ASSERT_THAT(shards_to_write[2], make_pair(0, 8192));
+
+  shards_to_write = s.offset_len_to_chunk_offset(make_pair(4090, 8200), chunk_count);
+  ASSERT_THAT(shards_to_write[0], make_pair(0, 8192));
+  ASSERT_THAT(shards_to_write[1], make_pair(0, 8192));
+  ASSERT_THAT(shards_to_write[2], make_pair(0, 8192));
+
+}


### PR DESCRIPTION
This is a prototype for support overwrite in erasure code. The design is mostly the same with https://github.com/athanatos/ceph/blob/wip-ec-overwrites/doc/dev/osd_internals/ec_overwrites.rst
The following are implemented features
1.refactor ECBackend && ReplicatedPG to support overwrite
   the overwrite path is separated from original. overwrite date first go into versioned ghobject, each shards(include no write) will get a xattr store overwrite version, offset, length.
2.implemented method support big stripe update, not efficient for small write.
   because each write will get whole stripe to reconstruct data then copy new data, and send to shards.
3.a simple apply way
   each overwrite will check overwrite count and size when data has on disk. an apply includes clone_range, remove, remove xattr and a pglog marked unrollbackable.
4.rollback, recovery
   rollback unapplied data is to remove the temp object.
   recovery will reverse check pglog, to get unapplied version.

TODO: 
1.performance optimization, include the delta update for small write.
2.scrub, the unapplied data will break the crc. so new scrub way is needed.
3.more tests, recovery has not been fully tested.
